### PR TITLE
Fixing service account name in cronjob and job

### DIFF
--- a/certs/templates/cronjob.yaml
+++ b/certs/templates/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: certs
+          serviceAccountName: {{ template "helper.fullname" . }}
           containers:
           - name: {{ template "helper.fullname" . }}
             image: {{ template "helper.image" . }}

--- a/certs/templates/job.yaml
+++ b/certs/templates/job.yaml
@@ -14,7 +14,7 @@ spec:
         app: {{ template "helper.name" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: certs
+      serviceAccountName: {{ template "helper.fullname" . }}
       containers:
       - name: {{ template "helper.fullname" . }}
         image: {{ template "helper.image" . }}


### PR DESCRIPTION
When performing the follow:

`helm install --name dev-certs --namespace dev --values values.yaml certs/certs`

The named release has a different name than "certs", so the hard coded service account in the jobs.yaml and cronjobs.yaml doesn't help.

A run of: `kubectl -n dev describe jobs/dev-certs` shows the following issue:
```
Events:
  Type     Reason        Age                  From            Message
  ----     ------        ----                 ----            -------
  Warning  FailedCreate  4m12s (x9 over 26m)  job-controller  Error creating: pods "dev-certs-" is forbidden: error looking up service account dev/certs: serviceaccount "certs" not found
```

The ServiceAccount is hardcoded to `certs`. This PR fixes it to use `helper.fullname` as you used elsewhere.