### PR TITLE
Fix invalid pod spec errors with job.yaml and cronjob.yaml

### DIFF
--- a/certs/templates/cronjob.yaml
+++ b/certs/templates/cronjob.yaml
@@ -11,12 +11,16 @@ spec:
   schedule: {{ .Values.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  concurrencyPolicy: Forbid
   jobTemplate:
     metadata:
       labels:
         app: {{ template "helper.name" . }}
         release: {{ .Release.Name }}
     spec:
+      backoffLimit: {{ .Values.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+      ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
       template:
         spec:
           serviceAccountName: {{ template "helper.fullname" . }}
@@ -35,7 +39,3 @@ spec:
 {{ toYaml . | indent 12 }}
             {{- end }}
           restartPolicy: Never
-          backoffLimit: {{ .Values.backoffLimit }}
-          activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
-          ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
-          concurrencyPolicy: Forbid

--- a/certs/templates/job.yaml
+++ b/certs/templates/job.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  backoffLimit: {{ .Values.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+  ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:
@@ -30,7 +33,3 @@ spec:
 {{ toYaml . | indent 8 }}
         {{- end }}
       restartPolicy: Never
-      backoffLimit: {{ .Values.backoffLimit }}
-      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
-      ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
-      concurrencyPolicy: Forbid


### PR DESCRIPTION
Move cronjob 'concurrencyPolicy' above 'jobTemplate' to make it easier to read and place it at the valid level.

Move job properties 'backoffLimit', 'activeDeadlineSeconds', 'ttlSecondsAfterFinished'  out of the pod  template.