### PR TITLE
Current certificate overwritten with empty secrets on skipped renewal

### DIFF
--- a/scripts/certs.sh
+++ b/scripts/certs.sh
@@ -306,7 +306,12 @@ generate_cert() {
 
   info "acme.sh return code: ${RC}"
 
-  if [ "${RC}" != "0" -a "${RC}" != "2" ]; then
+  if [ "${RC}" = "2" ]; then
+    info "Certificate current. No renewal needed"
+    return
+  fi
+
+  if [ "${RC}" != "0" ]; then
     info "An acme.sh error occurred"
     exit 1
   fi


### PR DESCRIPTION
I'm running into an issue with current certificates getting replaced with empty secrets.

On 1st run, a certificate is correctly created. When the cronjob fires to check for renewal, the certificate is current, so acme.sh returns 2 and doesn't create a certificate. `NEW_CERT_HASH` is empty, so it doesn't match `CURRENT_CERT_HASH` and updates the secret with 0 bytes for ca.crt, tls.crt, and tls.key.