### PR TITLE
Don't escape wildcard domain folders

### DIFF
--- a/scripts/certs.sh
+++ b/scripts/certs.sh
@@ -111,7 +111,7 @@ get_domain_folder() {
   fi
 
   local DOMAIN_FOLDER
-  DOMAIN_FOLDER="/acme.sh/$(echo "${DOMAIN_NAME}" | sed 's@\*@\\*@g')"
+  DOMAIN_FOLDER="/acme.sh/$(echo "${DOMAIN_NAME}")"
   
   if [ "${IS_ECC_CERTIFICATE}" = "true" ]; then
     DOMAIN_FOLDER="${DOMAIN_FOLDER}_ecc"


### PR DESCRIPTION
Closes #29 

The sed command was escaping `*.domain.com` with `\*.domain.com`, but the folder on disk is created as `*.domain.com`. This causes the existing folder to not be found and triggers the fallback to using the most recently modified folder. But the most recently modified folder is not the cert folder after running acme 