### PR TITLE
Allow restricting of secret resource names in role

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ manageAllNamespaces | `false` | Whether or not `certs` should manage all namespa
 debug | `false` | Display more logs when value is set to `"true"`.
 failedJobsHistoryLimit | `1` | Specify how many failed jobs should be kept.
 env | `[]` | List all environment variables needed to run a `acme.sh` dns validation for certificate renew.
+secretResourceNames | `[]` | Limit Role/ClusterRole access to a list of secrets. This should be a list of tls secrets used by ingress resources.
 demo.enabled | `false` | Enable a demo backend for test purpose.
 demo.image | `mathnao/light-test-server` | Set the docker image to use for the demo backend
 demo.service.type | `ClusterIP` | Set the service type for the demo backend

--- a/certs/templates/clusterrole.yaml
+++ b/certs/templates/clusterrole.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "update", "create"]
+  {{- if gt (len .Values.secretResourceNames) 0 }}
+  resourceNames:
+  {{- range .Values.secretResourceNames }}
+    - {{ . | quote }}
+    - {{ printf "%s-conf" . | quote }}
+  {{- end }}  
+  {{- end }}
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
   verbs: ["list"]

--- a/certs/templates/role.yaml
+++ b/certs/templates/role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "update", "create"]
+  {{- if gt (len .Values.secretResourceNames) 0 }}
+  resourceNames:
+  {{- range .Values.secretResourceNames }}
+    - {{ . | quote }}
+    - {{ printf "%s-conf" . | quote }}
+  {{- end }}  
+  {{- end }}
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
   verbs: ["list"]

--- a/certs/values.yaml
+++ b/certs/values.yaml
@@ -28,6 +28,8 @@ manageAllNamespaces: false
 
 env: []
 
+secretResourceNames: []
+
 demo:
   enabled: false
   image: mathnao/light-test-server


### PR DESCRIPTION
Some people (me :wink:) might not want to give access to all secrets in the  namespace(s) that certs runs in.

This PR allows limiting the list of secrets via the `resourceNames` directive in the Role/ClusterRole.

The `secret-name-conf` secret created by certs is automatically added, so for example
```yaml
secretResourceNames: ["my-secret"]
```

Would result in 

```yaml
resourceNames:
  - "my-secret"
  - "my-secret-conf"
```