### PR TITLE
Kubernetes 1.22 Updates

### DIFF
--- a/certs/templates/clusterrole.yaml
+++ b/certs/templates/clusterrole.yaml
@@ -14,7 +14,7 @@ rules:
     - {{ printf "%s-conf" . | quote }}
   {{- end }}  
   {{- end }}
-- apiGroups: ["extensions"]
+- apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["list"]
 {{- end -}}

--- a/certs/templates/cronjob.yaml
+++ b/certs/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "helper.fullname" . }}

--- a/certs/templates/ingress.yaml
+++ b/certs/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.demo.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "helper.fullname" . }}-demo-backend

--- a/certs/templates/role.yaml
+++ b/certs/templates/role.yaml
@@ -14,7 +14,7 @@ rules:
     - {{ printf "%s-conf" . | quote }}
   {{- end }}  
   {{- end }}
-- apiGroups: ["extensions"]
+- apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["list"]
 {{- end -}}

--- a/scripts/certs.sh
+++ b/scripts/certs.sh
@@ -171,7 +171,7 @@ starter() {
     acme.sh --set-default-ca --server letsencrypt
   fi
 
-  local URI="/apis/extensions/v1beta1"
+  local URI="/apis/networking.k8s.io/v1"
   if [ -n "${K8S_API_URI_NAMESPACE}" ]; then
     URI="${URI}/${K8S_API_URI_NAMESPACE}"
   fi


### PR DESCRIPTION
Updates all the namespaces which are no longer supported in Kubernetes 1.22, **with no effort made to maintain backwards compatibility**.

Fixes #51.

If anyone tries to use these, note that certs.sh was updated, so you'll need a new container image (accessible from your cluster) for a successful run. These changes are included in [chrismeller/certs](https://hub.docker.com/r/chrismeller/certs) for the time being.