### PR TITLE
Handle timeout loading conf secret

### DIFF
--- a/scripts/certs.sh
+++ b/scripts/certs.sh
@@ -96,6 +96,12 @@ k8s_api_call() {
   status_code=$(cat "${res_file}" | grep 'HTTP/' | awk '{printf $2}')
   add_to_report "$(cat "${res_file}")"
   rm -f "${res_file}"
+
+  if [ -z $status_code ]; then
+    info "Error loading k8s api ${uri}. Exiting to avoid potentially overwriting existing valid certs"
+    exit 1
+  fi
+
   echo "${status_code}"
 }
 


### PR DESCRIPTION
On my AKS cluster, requests to the k8s api sometimes timeout. Currently, the behavior of a timeout loading the conf secret results in generating a new cert without the previous configuration. That results in potentially bumping up on rate limits because cert renewal dates are never available and also rotates public/private keys, which can affect certificate pinning.

To fix, I'm exiting the script if the status code was not set when loading the conf secret. If you have a better way to handle, please let me know